### PR TITLE
Refactor Markdown.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-https://github.com/locp/testinfra-bdd/issues.
+info@locp.co.uk.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -116,7 +116,7 @@ the community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
@@ -124,5 +124,5 @@ enforcement ladder](https://github.com/mozilla/diversity).
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,11 +25,12 @@ Things that will make your branch more likely to be pulled:
 
 Tests are run against a branch pushes and pull requests using GitHub
 Workflows for this project these are visible at
-https://github.com/locp/testinfra-bdd/actions
+<https://github.com/locp/testinfra-bdd/actions>
 
 ## Cutting a Release
 
 Ensure your local repo is up-to-date:
+
 ```shell
 git checkout develop
 git fetch -p origin && git pull && git pull --tags
@@ -38,6 +39,7 @@ git pull
 ```
 
 Now set a shell variable to help us create the release:
+
 ```shell
 RELEASE='0.1.0'
 git flow release start $RELEASE
@@ -47,6 +49,7 @@ Now edit `testinfra_bdd/__init__.py` and ensure that the `__version__`
 variable is set to the same value as `$RELEASE`.
 
 Now update the `CHANGELOG.md` with:
+
 ```shell
 make changelog
 ```
@@ -66,7 +69,7 @@ git flow finish -m "v${RELEASE}" -p
 ```
 
 When all the CI jobs have completed, create the new release at
-https://github.com/locp/testinfra-bdd/releases
+<https://github.com/locp/testinfra-bdd/releases>
 
 ### Post Release Steps
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Feature: Example of Testinfra BDD
     Given the host with URL "docker://sut" is ready
     When the user is "ntp"
     Then the user is present
-    And the user state is present # Alternative method of checking the state of a resource.
+    # Alternative method of checking the state of a resource.
+    And the user state is present
     And the user group is ntp
     And the user uid is 101
     And the user gid is 101
@@ -258,7 +259,6 @@ When steps require that a "Given" step has been executed beforehand.  They
 allow the user to either skip tests if the host does not match an expected
 profile.  They also allow the user to specify which resource or is to be
 tested.
-
 
 ### Skip Tests if Host Profile Does Not Match
 

--- a/tests/features/example.feature
+++ b/tests/features/example.feature
@@ -34,7 +34,8 @@ Feature: Example of Testinfra BDD
     Given the host with URL "docker://sut" is ready
     When the user is "ntp"
     Then the user is present
-    And the user state is present # Alternative method of checking the state of a resource.
+    # Alternative method of checking the state of a resource.
+    And the user state is present
     And the user group is ntp
     And the user uid is 101
     And the user gid is 101


### PR DESCRIPTION
Use https://github.com/markdownlint/markdownlint to improve Markdown format.  Essentially excluded `CHANGLOG.md` in the CodeClimate config as it is auto-generated.  Fixed the rest of the bugs.  Fixes #42.