### PR TITLE
New Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Feature: Example of Testinfra BDD
     Then the command return code is 0
     And the command "ntpq" exists in path
     And the command stdout contains "remote"
+    And the command stdout does not contain "foo"
 
   Scenario: System Package
     Given the host with URL "docker://sut" is ready
@@ -116,7 +117,7 @@ Feature: Example of Testinfra BDD
     When the pip package is testinfra-bdd
     # Can check if the package is absent or present.
     Then the pip package is present
-    And the pip package version is 1.0.6
+    And the pip package version is 2.0.0
     # Check that installed packages have compatible dependencies.
     And the pip check is OK
 
@@ -191,6 +192,13 @@ Feature: Example of Testinfra BDD
     And the command stdout is empty
     And the command return code is 0
     And the package is installed
+
+  Scenario: Check for an Expected Value
+   # In this example we set the expected_value to "foo"
+   Given the host with URL "docker://sut" is ready
+   And the expected value is "foo"
+   When the command is "echo foo"
+   Then the command stdout contains the expected value
 ```
 
 and `tests/step_defs/test_example.py` contains the following:
@@ -198,7 +206,7 @@ and `tests/step_defs/test_example.py` contains the following:
 ```python
 """Examples of step definitions for Testinfra BDD feature tests."""
 import testinfra_bdd
-from pytest_bdd import scenarios
+from pytest_bdd import given, scenarios
 
 scenarios('../features/example.feature')
 
@@ -206,6 +214,17 @@ scenarios('../features/example.feature')
 # Ensure that the PyTest fixtures provided in testinfra-bdd are available to
 # your test suite.
 pytest_plugins = testinfra_bdd.PYTEST_MODULES
+
+
+@given('the expected value is "foo"', target_fixture='expected_value')
+def the_expected_value_is_foo():
+    """
+    The expected value is "foo".
+
+    The name and code is up to the user to develop.  However, the target
+    fixture must be called 'expected_value'.
+    """
+    return 'foo'
 ```
 
 ## "Given" Steps

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ attrs==22.1.0
 bandit==1.7.4
 build==0.8.0
 colorama==0.4.5
-coverage==6.4.4
+coverage==6.5.0
 flake8==5.0.4
 flake8-docstrings==1.6.0
 flake8-quotes==3.3.1
@@ -12,7 +12,7 @@ gitdb==4.0.9
 GitPython==3.1.27
 glob2==0.7
 iniconfig==1.1.1
-Mako==1.2.2
+Mako==1.2.3
 mando==0.6.4
 MarkupSafe==2.1.1
 mccabe==0.7.0
@@ -31,7 +31,7 @@ pyparsing==3.0.9
 pystache==0.6.0
 pytest==7.1.3
 pytest-bdd==6.0.1
-pytest-cov==3.0.0
+pytest-cov==4.0.0
 pytest-testinfra==6.8.0
 PyYAML==6.0
 radon==5.1.0

--- a/testinfra_bdd/__init__.py
+++ b/testinfra_bdd/__init__.py
@@ -3,6 +3,8 @@ An interface between pytest-bdd and pytest-testinfra.
 
 For documentation and examples, please go to
 https://github.com/locp/testinfra-bdd
+
+Please avoid already-imported warning: PYTEST_DONT_REWRITE.
 """
 from testinfra_bdd.fixture import TestinfraBDD
 

--- a/testinfra_bdd/then/command.py
+++ b/testinfra_bdd/then/command.py
@@ -75,6 +75,30 @@ def the_command_stderr_contains_the_expected_value(stream_name, expected_value, 
     assert expected_value in stream, message
 
 
+@then(parsers.parse('the command {stream_name} does not contain "{text}"'))
+def the_command_stdout_does_not_contain_foo(stream_name, text, testinfra_bdd_host):
+    """
+    Check that the stdout or stderr stream does not contain a string.
+
+    Parameters
+    ----------
+    stream_name : str
+        The name of the stream to check.  Must be "stdout" or "stderr".
+    text : str
+        The text to search for.
+    testinfra_bdd_host : testinfra_bdd.fixture.TestinfraBDD
+        The test fixture.
+
+    Raises
+    ------
+    AssertError
+        When the specified stream does contain the unexpected text.
+    """
+    stream = testinfra_bdd_host.get_stream_from_command(stream_name)
+    message = f'The unexpected string "{text}" was found in the {stream_name} ("{stream}") of the command.'
+    assert text not in stream, message
+
+
 @then(parsers.parse('the command {stream_name} contains the regex "{pattern}"'))
 def check_command_stream_contains_the_regex(stream_name, pattern, testinfra_bdd_host):
     """

--- a/testinfra_bdd/then/command.py
+++ b/testinfra_bdd/then/command.py
@@ -51,6 +51,30 @@ def check_command_stream_contains(stream_name, text, testinfra_bdd_host):
     assert text in stream, message
 
 
+@then(parsers.parse('the command {stream_name} contains the expected value'))
+def the_command_stderr_contains_the_expected_value(stream_name, expected_value, testinfra_bdd_host):
+    """
+    Check that the stdout or stderr stream contains a pre-defined expected value.
+
+    Parameters
+    ----------
+    stream_name : str
+        The name of the stream to check.  Must be "stdout" or "stderr".
+    expected_value : A pytest fixture.
+        This is pre-defined by the user.
+    testinfra_bdd_host : testinfra_bdd.fixture.TestinfraBDD
+        The test fixture.
+
+    Raises
+    ------
+    AssertError
+        When the specified stream does not contain the expected text.
+    """
+    stream = testinfra_bdd_host.get_stream_from_command(stream_name)
+    message = f'The string "{expected_value}" was not found in the {stream_name} ("{stream}") of the command.'
+    assert expected_value in stream, message
+
+
 @then(parsers.parse('the command {stream_name} contains the regex "{pattern}"'))
 def check_command_stream_contains_the_regex(stream_name, pattern, testinfra_bdd_host):
     """

--- a/testinfra_bdd/then/pip.py
+++ b/testinfra_bdd/then/pip.py
@@ -1,4 +1,8 @@
-"""Then pip package fixtures for testinfra-bdd."""
+"""
+Then pip package fixtures for testinfra-bdd.
+
+Please avoid already-imported warning: PYTEST_DONT_REWRITE.
+"""
 from pytest_bdd import (
     then,
     parsers

--- a/tests/features/example.feature
+++ b/tests/features/example.feature
@@ -73,6 +73,7 @@ Feature: Example of Testinfra BDD
     Then the command return code is 0
     And the command "ntpq" exists in path
     And the command stdout contains "remote"
+    And the command stdout does not contain "foo"
 
   Scenario: System Package
     Given the host with URL "docker://sut" is ready

--- a/tests/features/example.feature
+++ b/tests/features/example.feature
@@ -160,3 +160,10 @@ Feature: Example of Testinfra BDD
     And the command stdout is empty
     And the command return code is 0
     And the package is installed
+
+  Scenario: Check for an Expected Value
+   # In this example we set the expected_value to "foo"
+   Given the host with URL "docker://sut" is ready
+   And the expected value is "foo"
+   When the command is "echo foo"
+   Then the command stdout contains the expected value

--- a/tests/step_defs/test_example.py
+++ b/tests/step_defs/test_example.py
@@ -1,6 +1,6 @@
 """Examples of step definitions for Testinfra BDD feature tests."""
 import testinfra_bdd
-from pytest_bdd import scenarios
+from pytest_bdd import given, scenarios
 
 scenarios('../features/example.feature')
 
@@ -8,3 +8,9 @@ scenarios('../features/example.feature')
 # Ensure that the PyTest fixtures provided in testinfra-bdd are available to
 # your test suite.
 pytest_plugins = testinfra_bdd.PYTEST_MODULES
+
+
+@given('the expected value is "foo"', target_fixture='expected_value')
+def the_expected_value_is_foo():
+    """the expected value is "foo"."""
+    return 'foo'

--- a/tests/step_defs/test_example.py
+++ b/tests/step_defs/test_example.py
@@ -12,5 +12,10 @@ pytest_plugins = testinfra_bdd.PYTEST_MODULES
 
 @given('the expected value is "foo"', target_fixture='expected_value')
 def the_expected_value_is_foo():
-    """the expected value is "foo"."""
+    """
+    The expected value is "foo".
+
+    The name and code is up to the user to develop.  However, the target
+    fixture must be called 'expected_value'.
+    """
     return 'foo'


### PR DESCRIPTION
This PR delivers the following:

- Suppresses meaningless warnings (PytestAssertRewriteWarning: Module already imported so cannot be rewritten).
- Allows the user to programmatically set an expected value fixture for comparison against command streams (fixes #55).
- Allows the user to check that text is not contained in command streams (fixes #54).