### PR TITLE
Remove LGTM.com bling from README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # testinfra-bdd
 
 [![CI](https://github.com/locp/testinfra-bdd/actions/workflows/ci.yml/badge.svg)](https://github.com/locp/testinfra-bdd/actions/workflows/ci.yml)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/locp/testinfra-bdd.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/locp/testinfra-bdd/alerts/)
-[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/locp/testinfra-bdd.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/locp/testinfra-bdd/context:python)
 [![Maintainability](https://api.codeclimate.com/v1/badges/5482c55d78b369a0a55e/maintainability)](https://codeclimate.com/github/locp/testinfra-bdd/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/5482c55d78b369a0a55e/test_coverage)](https://codeclimate.com/github/locp/testinfra-bdd/test_coverage)
 [![testinfra-bdd](https://snyk.io/advisor/python/testinfra-bdd/badge.svg)](https://snyk.io/advisor/python/testinfra-bdd)

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,4 +1,0 @@
----
-path_classifiers:
-  test:
-    - exclude: /


### PR DESCRIPTION
This MR fixes #57, but should also wait until any PR provided by LGTM.com (see https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/#october-help-migrate-repositories-to-github-code-scanning).